### PR TITLE
Remove tables that should not exist from the output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Removed tables that should not exist from the output.
+
 v0.0.19
 
 * Switched to only adding concept type joins if they're actually needed.

--- a/lf-to-abstract-sql.ometajs
+++ b/lf-to-abstract-sql.ometajs
@@ -158,7 +158,8 @@ export ometa LF2AbstractSQL <: SBVRCompilerLibs {
 			?(fieldID !== false)
 			{baseTable.fields.splice(fieldID, 1)}
 		)?
-		AddTableField(baseTable, fkName, 'ForeignKey', required, null, {tableName: fkTable.name, fieldName: fkTable.idField}):fieldID
+		{{ tableName: fkTable.name, fieldName: fkTable.idField }}:references
+		AddTableField(baseTable, fkName, 'ForeignKey', required, null, references):fieldID
 		(	?fieldID
 			// Field already exists, so we manually set the required attr
 			{baseTable.fields[fieldID].required = required}
@@ -218,7 +219,8 @@ export ometa LF2AbstractSQL <: SBVRCompilerLibs {
 					GetTable(identifier.name):fkTable
 					(	?fkTable.primitive
 						AddTableField(linkTable, fieldName, fkTable.primitive, true)
-					|	AddTableField(linkTable, fieldName, 'ForeignKey', true, null, {tableName: fkTable.name, fieldName: fkTable.idField})
+					|	{{ tableName: fkTable.name, fieldName: fkTable.idField }}:references
+						AddTableField(linkTable, fieldName, 'ForeignKey', true, null, references)
 					)
 				|	['Verb' :verb :negated]
 				)+
@@ -682,8 +684,22 @@ export ometa LF2AbstractSQL <: SBVRCompilerLibs {
 			|	Rule
 			)+
 		]
-		{{}}:tables
-		-> {tables:this.tables, rules:this.rules}
+		{{}}:hasDependants
+		{
+			_.each(this.tables, function(table) {
+				_.each(table.fields, function(field) {
+					if (field.dataType === 'ForeignKey' || field.dataType === 'ConceptType') {
+						hasDependants[field.references.tableName] = true;
+					}
+				})
+			})
+		}
+		-> { // We omit any tables that are primitives and not depended upon.
+			tables: _.omitBy(this.tables, function(table, tableName) {
+				return table.primitive && !hasDependants[tableName];
+			}),
+			rules: this.rules
+		}
 	,
 
 	CreateTable =

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -43,7 +43,10 @@ module.exports = (builtInVocab = false) ->
 
 				seSoFar += input + '\n'
 				if property
-					expect(result).to.have.deep.property(property).to.deep.equal(matches)
+					if matches is undefined
+						expect(result).to.not.have.deep.property(property)
+					else
+						expect(result).to.have.deep.property(property).to.deep.equal(matches)
 				else if ruleSQL
 					lastRule = result.rules[result.rules.length - 1]
 					deleteWhereBodies(lastRule)


### PR DESCRIPTION
This is to remove the need to do the [check in abstract-sql-compiler](https://github.com/resin-io-modules/abstract-sql-compiler/blob/master/AbstractSQLCompiler.coffee#L106) and to allow [abstract-sql-odata-schema](https://github.com/resin-io-modules/abstract-sql-to-odata-schema/blob/master/AbstractSQL2ODataSchema.coffee#L21) to actually be generated from the output of lf-to-abstract-sql rather than from the output of abstract-sql-compiler, with the goal of including synonyms/synonymous form info (which is needed for "verb-term attrs", which is needed for device key scope)