### PR TITLE
Fix `updateModifiedAt` formatting

### DIFF
--- a/lf-to-abstract-sql.ometajs
+++ b/lf-to-abstract-sql.ometajs
@@ -2,9 +2,7 @@ var SBVRCompilerLibs = require('./sbvr-compiler-libs').SBVRCompilerLibs,
 	_ = require('lodash'),
 	updateModifiedAt = {
 		type: 'trigger',
-		body: '\
-NEW."modified at" = NOW();\n\
-RETURN NEW;',
+		body: 'NEW."modified at" = NOW();\nRETURN NEW;',
 		language: 'plpgsql'
 	};
 


### PR DESCRIPTION
The end result of the previous version was
```
	
NEW."modified at" = NOW();

RETURN NEW;
```
because ometajs handles the string differently to normal javascript, I've switched to a more basic format to help avoid that confusion and get it more nicely formatted and as expected as:
```
NEW."modified at" = NOW();
RETURN NEW;