### PR TITLE
4.x major version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,6 @@ buildSteps: &buildSteps
       command: npm test --loglevel warn
 
 jobs:
-  node-8:
-    docker:
-      - image: circleci/node:8
-    steps: *buildSteps
-
   node-10:
     docker:
       - image: circleci/node:10
@@ -34,7 +29,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - node-8
       - node-10
       - node-12
       - node-14

--- a/index.js
+++ b/index.js
@@ -1,39 +1,21 @@
-(function (root, factory) {
-	if (typeof define === 'function' && define.amd) {
-		// AMD. Register as an anonymous module.
-		define(['@balena/lf-to-abstract-sql/lf-to-abstract-sql-prep', '@balena/lf-to-abstract-sql/lf-to-abstract-sql'], factory);
-	} else if (typeof exports === 'object') {
-		// Node. Does not work with strict CommonJS, but
-		// only CommonJS-like enviroments that support module.exports,
-		// like Node.
-		module.exports = factory(
-			require('./lf-to-abstract-sql-prep'),
-			require('./lf-to-abstract-sql')
-		);
-	} else {
-		// Browser globals
-		root.LF2AbstractSQL = factory(LF2AbstractSQLPrep, LF2AbstractSQL);
-	}
-}(this, function (LF2AbstractSQLPrep, LF2AbstractSQL) {
-	LF2AbstractSQLPrep = LF2AbstractSQLPrep.LF2AbstractSQLPrep;
-	LF2AbstractSQL = LF2AbstractSQL.LF2AbstractSQL;
-	return {
-		LF2AbstractSQLPrep: LF2AbstractSQLPrep,
-		LF2AbstractSQL: LF2AbstractSQL,
-		translate: function(lf, types) {
+const { LF2AbstractSQLPrep } = require('./lf-to-abstract-sql-prep');
+const { LF2AbstractSQL } = require('./lf-to-abstract-sql');
+module.exports = {
+	LF2AbstractSQLPrep: LF2AbstractSQLPrep,
+	LF2AbstractSQL: LF2AbstractSQL,
+	translate: function (lf, types) {
+		lf = LF2AbstractSQLPrep.match(lf, 'Process');
+		var translator = LF2AbstractSQL.createInstance();
+		translator.addTypes(types);
+		return translator.match(lf, 'Process');
+	},
+	createTranslator: function (types) {
+		var translator = LF2AbstractSQL.createInstance();
+		translator.addTypes(types);
+		return function (lf) {
 			lf = LF2AbstractSQLPrep.match(lf, 'Process');
-			var translator = LF2AbstractSQL.createInstance();
-			translator.addTypes(types);
+			translator.reset();
 			return translator.match(lf, 'Process');
-		},
-		createTranslator: function(types) {
-			var translator = LF2AbstractSQL.createInstance();
-			translator.addTypes(types);
-			return function(lf) {
-				lf = LF2AbstractSQLPrep.match(lf, 'Process');
-				translator.reset();
-				return translator.match(lf, 'Process');
-			};
-		}
-	}
-}));
+		};
+	},
+};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 (function (root, factory) {
 	if (typeof define === 'function' && define.amd) {
 		// AMD. Register as an anonymous module.
-		define(['@resin/lf-to-abstract-sql/lf-to-abstract-sql-prep', '@resin/lf-to-abstract-sql/lf-to-abstract-sql'], factory);
+		define(['@balena/lf-to-abstract-sql/lf-to-abstract-sql-prep', '@balena/lf-to-abstract-sql/lf-to-abstract-sql'], factory);
 	} else if (typeof exports === 'object') {
 		// Node. Does not work with strict CommonJS, but
 		// only CommonJS-like enviroments that support module.exports,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@resin/lf-to-abstract-sql",
+  "name": "@balena/lf-to-abstract-sql",
   "version": "3.2.6",
   "description": "LF to Abstract SQL translator.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint-fix": "balena-lint --typescript --fix index.js",
     "pretest": "npm run prepare",
     "test": "mocha",
+    "posttest": "npm run lint",
     "prepublish": "require-npm4-to-publish",
     "prepare": "ometajs2js --commonjs --input lf-to-abstract-sql.ometajs --output lf-to-abstract-sql.js && ometajs2js --commonjs --input lf-to-abstract-sql-prep.ometajs --output lf-to-abstract-sql-prep.js && ometajs2js --commonjs --input sbvr-compiler-libs.ometajs --output sbvr-compiler-libs.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "LF to Abstract SQL translator.",
   "main": "index.js",
   "scripts": {
-    "lint": "balena-lint test",
+    "lint": "balena-lint test && balena-lint --typescript index.js",
+    "lint-fix": "balena-lint --typescript --fix index.js",
     "pretest": "npm run prepare",
     "test": "mocha",
     "prepublish": "require-npm4-to-publish",


### PR DESCRIPTION
* Drop support for node 8 
* Rename to @balena/lf-to-abstract-sql
* Convert from UMD module to commonjs module
* Include linting as part of the tests