### PR TITLE
Add .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Add .npmrc to stop generating package-lock.json on npm install

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>