### PR TITLE
replace attribute check with single this.tables lookup

### DIFF
--- a/lf-to-abstract-sql.ometajs
+++ b/lf-to-abstract-sql.ometajs
@@ -192,7 +192,6 @@ export ometa LF2AbstractSQL <: SBVRCompilerLibs {
 	AttrDatabaseAttribute :factType =
 		:attrVal
 		(	?attrVal
-			{this.attributes[factType] = attrVal}
 			GetResourceName(factType):linkResourceName
 			{delete this.relationships[linkResourceName]}
 			{this.tables[linkResourceName] = 'Attribute'}
@@ -856,7 +855,7 @@ export ometa LF2AbstractSQL <: SBVRCompilerLibs {
 		},
 	ProcessAtomicFormulationsAttributes :unmappedFactType :actualFactType =
 		RoleBindings(actualFactType):binds
-		(	?(this.attributes.hasOwnProperty(unmappedFactType) && this.attributes[unmappedFactType])
+		(	?(this.GetTable(unmappedFactType) === 'Attribute')
 			// Find the "base" binding - the one that isn't primitive
 			{binds.find(function(bind) {
 				return !$elf.IsPrimitive($elf.ReconstructIdentifier(bind.identifier));
@@ -1261,7 +1260,6 @@ LF2AbstractSQL.reset = function() {
 	this.relationships = {};
 	this.synonymousForms = {};
 	this.rules = [];
-	this.attributes = {};
 	this.bindAttributes = [];
 	this.lfInfo = {
 		rules: {}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   "repository": "https://github.com/balena-io-modules/lf-to-abstract-sql.git",
   "author": "",
   "license": "BSD",
+  "engines": {
+    "node": ">=22.2.0",
+    "npm": ">=10.7.0"
+  },
   "dependencies": {
     "@balena/sbvr-parser": "^1.4.3",
     "lodash": "^4.17.21",

--- a/test/pilots.js
+++ b/test/pilots.js
@@ -305,45 +305,26 @@ describe('pilots', function () {
 									[
 										'And',
 										[
-											'And',
+											'LessThanOrEqual',
 											[
-												'LessThanOrEqual',
+												'CharacterLength',
 												[
-													'CharacterLength',
-													[
-														'ReferencedField',
-														// TODO: This is wrong and it should instead be the table's alias
-														'pilot certification.0-has-certification name.1',
-														'certification name',
-													],
-												],
-												['Integer', 64],
-											],
-											[
-												'Exists',
-												[
-													'CharacterLength',
-													[
-														'ReferencedField',
-														// TODO: This is wrong and it should instead be the table's alias
-														'pilot certification.0-has-certification name.1',
-														'certification name',
-													],
+													'ReferencedField',
+													'pilot certification.0',
+													'certification name',
 												],
 											],
+											['Integer', 64],
 										],
 										[
-											'Equals',
+											'Exists',
 											[
-												'ReferencedField',
-												'pilot certification.0',
-												'certification name',
-											],
-											[
-												'ReferencedField',
-												// TODO: This is wrong and it should instead be the table's alias
-												'pilot certification.0-has-certification name.1',
-												'certification name',
+												'CharacterLength',
+												[
+													'ReferencedField',
+													'pilot certification.0',
+													'certification name',
+												],
 											],
 										],
 									],
@@ -351,8 +332,7 @@ describe('pilots', function () {
 										'Exists',
 										[
 											'ReferencedField',
-											// TODO: This is wrong and it should instead be the table's alias
-											'pilot certification.0-has-certification name.1',
+											'pilot certification.0',
 											'certification name',
 										],
 									],


### PR DESCRIPTION
this.attributes was a redundant registry that
only AttrDatabaseAttribute ever wrote to, causing
the term-form case to be missed. All other rules
already use GetTable() === 'Attribute' so align
ProcessAtomicFormulationsAttributes with the same
pattern.

Change-type: patch
See: https://balena.fibery.io/Work/Project/Create-session-tables-for-API-VPN-connectivity-2031
See: https://balena.fibery.io/Work/Project/2429